### PR TITLE
ENH: build for multiple linux distros + copy client info in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ cache:
 before_script:
   # Replace clientId and clientSecret values in app-config.js with environment
   # variable values.
-  - set -eu
   - cd eapp/config/
   - cp ref-config.js app-config.js
   - sed -i -e "s/exports.clientId = ''/exports.clientId = \"$clientId\"/g" app-config.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
     - os: linux
       sudo: required
       services: docker
+      language: generic
 
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ before_script:
   - cp ref-config.js app-config.js
   - sed -i -e "s/exports.clientId = ''/exports.clientId = \"$clientId\"/g" app-config.js
   - sed -i -e "s/exports.clientSecret = ''/exports.clientSecret = \"$clientSecret\"/g" app-config.js
+  - cd ../../
 
 script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,15 @@ cache:
   - $HOME/.cache/electron
   - $HOME/.cache/electron-builder
 
+before_script:
+  # Replace clientId and clientSecret values in app-config.js with environment
+  # variable values.
+  - set -eu
+  - cd eapp/config/
+  - cp ref-config.js app-config.js
+  - sed -i -e "s/exports.clientId = ''/exports.clientId = \"$clientId\"/g" app-config.js
+  - sed -i -e "s/exports.clientSecret = ''/exports.clientSecret = \"$clientSecret\"/g" app-config.js
+
 script:
   - |
     if [ "$TRAVIS_OS_NAME" == "linux" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ before_script:
   # Replace clientId and clientSecret values in app-config.js with environment
   # variable values.
   - cd eapp/config/
-  - cp ref-config.js app-config.js
   - sed -i -e "s/exports.clientId = ''/exports.clientId = \"$clientId\"/g" app-config.js
   - sed -i -e "s/exports.clientSecret = ''/exports.clientSecret = \"$clientSecret\"/g" app-config.js
   - cd ../../

--- a/package.json
+++ b/package.json
@@ -13,9 +13,7 @@
     "appId": "org.repronim.brainverse",
     "linux": {
       "category": "Education",
-      "target": [
-        "AppImage"
-      ]
+      "target": ["AppImage", "deb", "rpm"]
     },
     "mac": {
       "category": "public.app-category.education",
@@ -23,7 +21,7 @@
     }
   },
   "keywords": [],
-  "author": "Smruti Padhy",
+  "author": "Smruti Padhy <smruti@mit.edu>",
   "license": "Apache 2",
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
Addresses #119 and #123.

This PR proposes building Linux `deb` and `rpm` packages and copying the `clientId` and `clientSecret` into the `app-config.js` file when building on Travis. The `deb` and `rpm` packages will satisfy Debian and RedHat derivatives (e.g., Debian, Ubuntu, CentOS, Fedora, etc.). An author email is necessary to build these.

In the near future, the built packages should be uploaded to some repository, perhaps Dropbox. TravisCI can upload these artifacts to GitHub releases [[docs](https://docs.travis-ci.com/user/deployment/releases/)]. The `docker` command in the `.travis.yml` file can also be run locally to get the same artifacts.