### PR TITLE
use specific docker image (using sha256) instead of latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ script:
         -v $(pwd):/project \
         -v ~/.cache/electron:/root/.cache/electron \
         -v ~/.cache/electron-builder:/root/.cache/electron-builder \
-        electronuserland/builder:latest \
+        electronuserland/builder@sha256:be4be15a1acffa57ef99b9e3ded821c79ad60c294a325da14ca31a526d1d0d6d \
         bash -c "
           yarn --link-duplicates --pure-lockfile \
           && yarn dist --linux --win


### PR DESCRIPTION
Fixes #153.

This PR proposes the use of a specific electron-builder Docker image instead of using latest. Images tagged `latest` are subject to change unexpectedly, whereas referencing an image with a shasum will use the same image every time.