### PR TITLE
fixing author in package.json and adding contributors

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,11 @@
     }
   },
   "keywords": [],
-  "author": ["Smruti Padhy <smruti@mit.edu>", "Sanu Ann Abraham <sanuann@mit.edu>"],
+  "author": "Smruti Padhy <smruti@mit.edu>",
+  "contributors": [
+    "Smruti Padhy <smruti@mit.edu>",
+    "Sanu Ann Abraham <sanuann@mit.edu>"
+  ],
   "license": "Apache 2",
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
@sanuann : I closed previous PRs, since encrypted `GH_TOKEN` will not work: https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions
I did create a new branch on ReproNim to create this PRs, so Travis is able to get the token.

So at the end this PR has only change  author in `package.json`. According to this [site](https://yarnpkg.com/lang/en/docs/package-json/) this should be one person (I don't know if this should be the main author or the current  maintainer).
  I added a list of contributors instead (you might want to extend it)
